### PR TITLE
add slack-generic-client executable

### DIFF
--- a/README-slack-generic-client.md
+++ b/README-slack-generic-client.md
@@ -1,0 +1,7 @@
+# slack-generic-client
+
+This executable lets you test the Slack API. First get a TOKEN.
+
+Then invoke the client like this:
+
+    slack-generic-client -t TOKEN auth.test ""

--- a/slack-hs.cabal
+++ b/slack-hs.cabal
@@ -24,6 +24,21 @@ library
     hs-source-dirs:      src
     default-language:    Haskell2010
 
+executable  slack-generic-client
+    hs-source-dirs: src
+    main-is: generic-client/Main.hs
+    build-depends:       base >=4.6,
+                         slack-hs,
+                         optparse-applicative,
+                         http-client,
+                         http-client-tls,
+                         http-types,
+                         aeson,
+                         containers,
+                         bytestring,
+                         text
+    default-language:    Haskell2010
+
 test-suite hspec
     build-depends:    base, slack-hs, hspec
     default-language: Haskell2010

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,3 +2,5 @@
 module Main where
 
 import qualified Network.Slack.Api as Slack
+
+main = undefined

--- a/src/generic-client/Main.hs
+++ b/src/generic-client/Main.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+module Main where
+import qualified Network.Slack.Api as Slack
+import Options.Applicative 
+import Control.Applicative
+import Network.HTTP.Types.URI (parseQuery)
+import qualified Data.ByteString.Char8 as B
+
+data Options = Options {
+    token :: String
+  , endpoint :: String
+  , params :: [(String, String)]
+  } deriving (Show, Eq)
+
+parseOptions :: Parser Options
+parseOptions = Options 
+    <$> strOption (long "token" <> short 't' <> metavar "TOKEN" <> help "Auth token")
+    <*> strArgument (metavar "ENDPOINT" <> help "endpoint, e.g. channels.list")
+    <*> (parseParams <$>
+        (strArgument (metavar "PARAMS" <> help "API request params in request query format")))
+
+parseParams :: String -> [(String, String)]
+parseParams xs = 
+    let xs' = parseQuery $ B.pack xs
+    in [(B.unpack a, B.unpack b) | (a,Just b) <- xs']
+
+opts = info (helper <*> parseOptions)
+            (fullDesc 
+             <> progDesc "Probe the Slack API"
+             <> header "slack-generic-client")
+
+main = do
+    Options{..} <- execParser opts
+    r <- Slack.request token endpoint params
+    print r
+    putStrLn "Done"
+
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,35 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.5
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
Two changes in this commit:
1. I added a stack.yaml so we can build with stackage.
2. I created an executable `stack-generic-client` that one can use to probe the Stack API using the client library. This is mainly for development purposes, but it might evolve into a more full-featured command line stack client.
