### PR TITLE
Build.fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work

--- a/slack-hs.cabal
+++ b/slack-hs.cabal
@@ -17,6 +17,7 @@ library
                          http-client,
                          http-client-tls,
                          http-types,
+                         optparse-applicative,
                          aeson,
                          containers,
                          bytestring,

--- a/slack-hs.cabal
+++ b/slack-hs.cabal
@@ -27,7 +27,7 @@ library
 
 executable  slack-generic-client
     hs-source-dirs: src
-    main-is: generic-client/Main.hs
+    main-is: Main.hs
     build-depends:       base >=4.6,
                          slack-hs,
                          optparse-applicative,


### PR DESCRIPTION
@owainlewis 

Hello! Here is some fixes for stack build:
- .gitignore entry for stack stuff
- fixed  executable  slack-generic-client section of stack-hs
- and also there is an error that optparse-applicative missing while building a library ... 
