### PR TITLE
Bump stack solver to lts-8.9. Add (<>) import.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,6 +4,7 @@ module Main
   ) where
 
 import qualified Network.Slack.Api as Slack
+import Data.Monoid ((<>))
 import Options.Applicative 
 import Control.Applicative
 import Network.HTTP.Types.URI (parseQuery)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.5
+resolver: lts-8.9
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
`stack build` succeeded. Hope this works out-of-the-box. Please advise on any changes if needed. Thanks.